### PR TITLE
create database for org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,7 @@
 # STARTER-team01
 
-Instructions: <https://ucsb-cs156.github.io/s26/lab/team01.html>
+Deployments:<https://team01-andy-org.dokku-01.cs.ucsb.edu/>
 
-TODO: change heading above to your repo name, e.g. `# team01-s26-17`
-
-TODO: Add a link to the deployed Dokku app for your team here, e.g.
-
-Deployments:
-
-* Prod: <https://team01.dokku-17.cs.ucsb.edu>
-* QA: <https://team01-qa.dokku-17.cs.ucsb.edu>
-
-TODO: Fill in this table with correct information. 
 
 | Table                     | Name         | Github Id |
 |---------------------------|--------------|-----------|
@@ -30,21 +20,6 @@ after completing your own.
 * Java: 21
 * node: 20.17.0
 See [docs/versions.md](docs/versions.md) for more information on upgrading versions.
-
-# Brief overview of starter code 
-
-TODO: remove this header and content of this section before submitting.
-However leave the section `# Overview of application` and its content 
-intact.
-
-The starter code here starts with a base similar to `team01`, but with 
-some extra frontend code on top of the of backend CRUD operations
-that were present in `team01`.
-
-You can use this code as a basis to:
-* Add the backend code from team01 *in stages* as suggested in the issues (doing that in "one giant pull request" is *not recommended) 
-* Add a frontend on top of the backend CRUD features you added in team01, using the existing
-  code as examples.
 
 # Overview of application
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "UCSBORGANIZATIONS")
+public class UCSBOrganization {
+  @Id private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,65 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "UCSBOrganization-1",
+        "author": "a-Fat-Cat",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBORGANIZATIONS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "UCSBORGANIZATIONS",
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBORGANIZATIONS_PK",
+                      "nullable": false
+                    },
+                    "name": "ORG_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORG_TRANSLATION_SHORT",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORG_TRANSLATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "INACTIVE",
+                    "type": "BOOLEAN"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #14 

Added database for UCSB org

Verified locally in H2 console: UCSBORGANIZATIONS table exists with columns ORG_CODE, ORG_TRANSLATION_SHORT, ORG_TRANSLATION, and INACTIVE.

Verified on Dokku Postgres:

dokku postgres:connect team01-andy-org-db
\dt
\d ucsborganizations

The ucsborganizations table exists with columns org_code, org_translation_short, org_translation, and inactive. org_code is the primary key.


<img width="209" height="106" alt="Screenshot 2026-04-28 144530" src="https://github.com/user-attachments/assets/20b09deb-9963-4d45-86bc-d63d9f636bc8" />
