### PR TITLE
feat: MenuItemReview Add GET (all) and POST (create) endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  @Operation(summary = "List all menu item reviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allMenuItemReviews() {
+    Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+    return reviews;
+  }
+
+  @Operation(summary = "Create a new review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postMenuItemReview(
+      @Parameter(name = "itemId") @RequestParam Long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars") @RequestParam int stars,
+      @Parameter(
+              name = "dateReviewed",
+              description = "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS)")
+          @RequestParam("dateReviewed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments) {
+
+    log.info(
+        "postMenuItemReview: itemId={}, reviewerEmail={}, stars={}, dateReviewed={}, comments={}",
+        itemId,
+        reviewerEmail,
+        stars,
+        dateReviewed,
+        comments);
+
+    MenuItemReview review = new MenuItemReview();
+    review.setItemId(itemId);
+    review.setReviewerEmail(reviewerEmail);
+    review.setStars(stars);
+    review.setDateReviewed(dateReviewed);
+    review.setComments(comments);
+
+    MenuItemReview savedReview = menuItemReviewRepository.save(review);
+
+    return savedReview;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,108 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+  @MockBean MenuItemReviewRepository menuItemReviewRepository;
+
+  @MockBean UserRepository userRepository;
+
+  // GET ALL
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().isOk());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview review1 =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("user1@test.com")
+            .stars(5)
+            .dateReviewed(ldt1)
+            .comments("Great")
+            .build();
+
+    ArrayList<MenuItemReview> expectedReviews = new ArrayList<>();
+    expectedReviews.addAll(Arrays.asList(review1));
+
+    when(menuItemReviewRepository.findAll()).thenReturn(expectedReviews);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedReviews);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  // POST
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_review() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview review1 =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("admin@test.com")
+            .stars(5)
+            .dateReviewed(ldt1)
+            .comments("Awesome")
+            .build();
+
+    when(menuItemReviewRepository.save(eq(review1))).thenReturn(review1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/menuitemreview/post?itemId=1&reviewerEmail=admin@test.com&stars=5&dateReviewed=2022-01-03T00:00:00&comments=Awesome")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).save(review1);
+    String expectedJson = mapper.writeValueAsString(review1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Fix for issue #27

Added the ability to store and retrieve Menu Item Reviews in the backend. This allows users to see a list of all reviews and allows administrators to create new review entries.

Details for Reviewers:

Created ```MenuItemReviewController.java``` with two endpoints:

GET ```/api/menuitemreview/all: ``` Returns a list of all reviews in the database.

POST ```api/menuitemreview/post:``` Accepts parameters ```(itemId, reviewerEmail, stars, dateReviewed, comments)``` to save a new review.

Added ```MenuItemReviewControllerTests.java``` to ensure 100% code coverage and no surviving Pitest mutations.

Test Instruction
1. Run application locally (mvn spring-boot:run)
2. Open http://localhost:8080
3. Log in as admin
4. Click Swagger API Links
5. Use the ```POST``` endpoint to add a sample review (e.g., Item ID: 1, Stars: 5, Comments: "Delicious!").
6. Use the ```GET /all``` endpoint to verify that your new review appears in the JSON response.

<img width="1491" height="199" alt="image" src="https://github.com/user-attachments/assets/43109860-9918-452a-bd2e-998210995cd8" />
