### PR TITLE
Add: MenuItemReview PUT (edit) endpoint, PUT (edit) endpoint, DELETE endpoint, and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,17 +1,22 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -65,5 +70,75 @@ public class MenuItemReviewController extends ApiController {
     MenuItemReview savedReview = menuItemReviewRepository.save(review);
 
     return savedReview;
+  }
+
+  /**
+   * Get a single record from the table; use the value passed in as a @RequestParam to do a lookup
+   * by id. If a matching row is found, return the row as a JSON object, otherwise throw an
+   * EntityNotFoundException.
+   *
+   * @param id the id of the review
+   * @return a MenuItemReview
+   */
+  @Operation(summary = "Get a single review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public MenuItemReview getById(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return menuItemReview;
+  }
+
+  /**
+   * Get a single record from the table; use the value passed in as a @RequestParam to do a lookup
+   * by id. If a matching row is found, update that row with the values passed in as a JSON object.
+   * If a matching row is not found, throw an EntityNotFoundException.
+   *
+   * @param id id of the review to update
+   * @param incoming the new review
+   * @return the updated review object
+   */
+  @Operation(summary = "Update a single review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReview.setItemId(incoming.getItemId());
+    menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+    menuItemReview.setStars(incoming.getStars());
+    menuItemReview.setDateReviewed(incoming.getDateReviewed());
+    menuItemReview.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(menuItemReview);
+
+    return menuItemReview;
+  }
+
+  /**
+   * Delete a review * @param id the id of the review to delete
+   *
+   * @return a message indicating the review was deleted
+   */
+  @Operation(summary = "Delete a review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItemReview(@Parameter(name = "id") @RequestParam Long id) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReviewRepository.delete(menuItemReview);
+    return genericMessage("MenuItemReview with id %s deleted".formatted(id));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -105,4 +105,200 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
+
+  // GET BY ID
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("user@test.com")
+            .stars(4)
+            .dateReviewed(ldt)
+            .comments("Nice")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(java.util.Optional.of(review));
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreview?id=7")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(review);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(java.util.Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/menuitemreview?id=7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    java.util.Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+  }
+
+  // PUT (UPDATE)
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_review() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-06-15T12:00:00");
+
+    MenuItemReview originalReview =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("user@test.com")
+            .stars(3)
+            .dateReviewed(ldt1)
+            .comments("Okay")
+            .build();
+
+    MenuItemReview updatedReview =
+        MenuItemReview.builder()
+            .itemId(2L)
+            .reviewerEmail("updated@test.com")
+            .stars(5)
+            .dateReviewed(ldt2)
+            .comments("Actually great")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(updatedReview);
+
+    when(menuItemReviewRepository.findById(eq(7L)))
+        .thenReturn(java.util.Optional.of(originalReview));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview?id=7")
+                    .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    verify(menuItemReviewRepository, times(1)).save(originalReview);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_review_that_does_not_exist() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview updatedReview =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("user@test.com")
+            .stars(5)
+            .dateReviewed(ldt)
+            .comments("Great")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(updatedReview);
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(java.util.Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview?id=7")
+                    .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    java.util.Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+  }
+
+  // DELETE
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_review() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("user@test.com")
+            .stars(5)
+            .dateReviewed(ldt)
+            .comments("Great")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(java.util.Optional.of(review));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview?id=7").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    verify(menuItemReviewRepository, times(1)).delete(review);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals("{\"message\":\"MenuItemReview with id 7 deleted\"}", responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_delete_review_that_does_not_exist() throws Exception {
+
+    // arrange
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(java.util.Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview?id=7").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    java.util.Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+  }
 }


### PR DESCRIPTION
Solves Issue #28  , #29 , and #30 

Added the remaining CRUD functionality for Menu Item Reviews. Users can now view a single review by its ID, and administrators can update or delete existing reviews via the backend API.

Details: 
GET ```/api/menuitemreview?id=...```: Retrieves a single review. Throws a 404 if the ID is invalid.

PUT ```/api/menuitemreview?id=...```: Updates an existing review using a JSON request body. Only accessible by Admins.

DELETE ```/api/menuitemreview?id=...```: Removes a review from the database. Only accessible by Admins.

Coverage: Added comprehensive tests in ```MenuItemReviewControllerTests.java``` for all new endpoints, achieving 100% JaCoCo coverage and passing Pitest mutation testing.

<img width="1453" height="342" alt="image" src="https://github.com/user-attachments/assets/f61d33a7-6f07-4b46-9847-8637d978b6f9" />

How to test:
1. Run the app via ```mvn spring-boot:run``` and open Swagger (http://localhost:8080/swagger-ui/index.html).
2. Test GET: Try to retrieve a review by an ID that exists. Then try ID 999 to check that the "not found" error works.
3. Test PUT: As an Admin, use the PUT endpoint. Provide an existing ID and a JSON body with updated fields. Verify the response shows the changes.
4. Test DELETE: As an Admin, delete a specific record. Verify that a subsequent GET for that same ID returns a 404.

<img width="1429" height="740" alt="image" src="https://github.com/user-attachments/assets/2c1984b1-bc5a-4658-8d06-22f2527f1b0a" />

<img width="1421" height="317" alt="image" src="https://github.com/user-attachments/assets/951a9b0c-43bd-4ae9-bf80-16cb6a95a5a6" />



